### PR TITLE
Update to use new parsing of receipts, and add more forms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - *test
   build_python3:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3
     steps:
       - checkout
       - restore_cache:
@@ -87,7 +87,7 @@ jobs:
       - *test
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3
     steps:
       - checkout
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ nosetests.xml
 # Testing
 *.bin
 *.pem
+*.cer
 .pytest_cache

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Educreations, Inc.
+Copyright (c) 2020 Educreations, Inc.
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Python utilities for working with Apple In-App Purchases (IAP)
 
 ## Copyright
 
-Copyright © 2019, Educreations, Inc under the MIT software license. See LICENSE for more information.
+Copyright © 2020, Educreations, Inc under the MIT software license. See LICENSE for more information.

--- a/iap/forms.py
+++ b/iap/forms.py
@@ -5,6 +5,8 @@ import json
 from django import forms
 import pytz
 
+from .widgets import IAPNullBooleanSelect
+
 
 EXPIRATION_INTENT_CHOICES = [
     (1, "Voluntary cancellation"),
@@ -144,10 +146,10 @@ class AppleLatestReceiptInfoForm(forms.Form):
 
     # An indicator of whether an auto-renewable subscription is in the introductory
     # price period.
-    is_in_intro_offer_period = forms.NullBooleanField()
+    is_in_intro_offer_period = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # An indicator of whether a subscription is in the free trial period.
-    is_trial_period = forms.NullBooleanField()
+    is_trial_period = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # The number of consumable products purchased. This value corresponds to the
     # quantity property of the SKPayment object stored in the transaction's payment
@@ -198,14 +200,14 @@ class AppleUnifiedLatestReceiptInfoForm(forms.Form):
 
     # An indicator of whether an auto-renewable subscription is in the introductory
     # price period.
-    is_in_intro_offer_period = forms.NullBooleanField()
+    is_in_intro_offer_period = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # An indicator of whether a subscription is in the free trial period.
-    is_trial_period = forms.NullBooleanField()
+    is_trial_period = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # An indicator that a subscription has been canceled due to an upgrade. This
     # field is only present for upgrade transactions.
-    is_upgraded = forms.NullBooleanField()
+    is_upgraded = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # The time of the original app purchase. This value indicates the date of the
     # subscription's initial purchase. The original purchase date applies to all
@@ -287,7 +289,7 @@ class AppleUnifiedPendingRenewalInfoForm(forms.Form):
     # The current renewal status for an auto-renewable subscription product. Note
     # that these values are different from those of the auto_renew_status in the
     # receipt.
-    auto_renew_status = forms.NullBooleanField()
+    auto_renew_status = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # The reason a subscription expired. This field is only present for an expired
     # auto-renewable subscription.
@@ -303,7 +305,7 @@ class AppleUnifiedPendingRenewalInfoForm(forms.Form):
     # A flag that indicates Apple is attempting to renew an expired subscription
     # automatically. This field is only present if an auto-renewable subscription
     # is in the billing retry state.
-    is_in_billing_retry_period = forms.NullBooleanField()
+    is_in_billing_retry_period = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # The transaction identifier of the original purchase.
     # See https://developer.apple.com/documentation/appstorereceipts/original_transaction_id
@@ -443,7 +445,7 @@ class AppleStatusUpdateForm(forms.Form):
     # The current renewal status for an auto-renewable subscription product. Note
     # that these values are different from those of the auto_renew_status in the
     # receipt.
-    auto_renew_status = forms.NullBooleanField()
+    auto_renew_status = forms.NullBooleanField(widget=IAPNullBooleanSelect)
 
     # The time at which the renewal status for an auto-renewable subscription was
     # turned on or off.

--- a/iap/forms.py
+++ b/iap/forms.py
@@ -3,6 +3,7 @@ import datetime
 import json
 
 from django import forms
+import pytz
 
 
 EXPIRATION_INTENT_CHOICES = [
@@ -24,7 +25,7 @@ def _clean_date(data, name, required=True):
 
         # the date in ms
         seconds = int(value) / 1000.0
-        return datetime.datetime.fromtimestamp(seconds, tz=datetime.timezone.utc)
+        return datetime.datetime.fromtimestamp(seconds, tz=pytz.utc)
 
     if required:
         raise forms.ValidationError("Unable to find a date for {}".format(name))

--- a/iap/forms.py
+++ b/iap/forms.py
@@ -1,7 +1,372 @@
 import base64
+import datetime
 import json
 
 from django import forms
+
+
+EXPIRATION_INTENT_CHOICES = [
+    (1, "Voluntary cancellation"),
+    (2, "Billing error"),
+    (3, "Declined price change"),
+    (4, "Product not available at renewal"),
+    (5, "Unknown error"),
+]
+
+
+def _clean_date(data, name, required=True):
+    # Try to get the value in ms
+    for key in (name + "_ms", name):
+        if key not in data:
+            continue
+
+        value = data.get(key)
+
+        # the date in ms
+        seconds = int(value) / 1000.0
+        return datetime.datetime.fromtimestamp(seconds, tz=datetime.timezone.utc)
+
+    if required:
+        raise forms.ValidationError("Unable to find a date for {}".format(name))
+
+    return None
+
+
+def _clean_receipt(name, value):
+    if not value:
+        return None
+
+    try:
+        # Ensure the receipt can be base 64 decoded
+        return base64.b64decode(value)
+    except TypeError:
+        raise forms.ValidationError("Unable to decode {}".format(name))
+
+
+def _parse_json(name, value):
+    # The following is to support py2 and py3
+    # https://stackoverflow.com/a/22679982
+    try:
+        basestring  # noqa
+    except NameError:
+        basestring = (str, bytes)
+
+    # Is this already decoded?
+    if isinstance(value, basestring):
+        # Decode the json value
+        try:
+            return json.loads(value)
+        except ValueError as e:
+            raise forms.ValidationError("Unable to parse {}: {}".format(name, e))
+    else:
+        return value
+
+
+def _clean_form_data(form_cls, name, value):
+    if not value:
+        return None
+
+    loaded = _parse_json(name, value)
+
+    if isinstance(loaded, list):
+        raise forms.ValidationError("Unable to parse list {}: {}".format(name, loaded))
+
+    # Try to decode some of things in the json
+    form = form_cls(loaded)
+    if not form.is_valid():
+        raise forms.ValidationError(
+            "Unable to parse {}: {}".format(name, form.errors.as_data())
+        )
+    return form.cleaned_data
+
+
+def _clean_list_of_form_data(form_cls, name, value):
+    if not value:
+        return None
+
+    loaded = _parse_json(name, value)
+
+    if not isinstance(loaded, list):
+        raise forms.ValidationError(
+            "Unable to parse non list {}: {}".format(name, loaded)
+        )
+
+    return [
+        _clean_form_data(form_cls, "{}[{}]".format(name, i), item)
+        for i, item in enumerate(loaded)
+    ]
+
+
+class AppleLatestReceiptInfoForm(forms.Form):
+    """
+    A Django form to validate receipt info
+
+    See https://developer.apple.com/documentation/appstoreservernotifications/responsebody/latest_receipt_info
+    """
+
+    # An identifier that App Store Connect generates and the App Store uses to uniquely
+    # identify the app purchased. Treat this value as a 64-bit integer.
+    app_item_id = forms.IntegerField()
+
+    # An identifier that App Store Connect generates and the App Store uses to uniquely
+    # identify the in-app product purchased. Treat this value as a 64-bit integer.
+    item_id = forms.IntegerField()
+
+    # The unique identifier of the product purchased. You provide this value when
+    # creating the product in App Store Connect, and it corresponds to the
+    # productIdentifier property of the SKPayment object stored in the transaction's
+    # payment property.
+    product_id = forms.CharField()
+
+    # The time of the original app purchase. This value indicates the date of the
+    # subscription's initial purchase. The original purchase date applies to all
+    # product types and remains the same in all transactions for the same product
+    # ID. This value corresponds to the original transaction's transactionDate
+    # property in StoreKit.
+    original_purchase_date = forms.Field()
+
+    # The time the App Store charged the user's account for a subscription purchase
+    # or renewal after a lapse.
+    purchase_date = forms.Field()
+
+    # The time a subscription expires or when it will renew. Note that this field is
+    # called expires_date_ms in the receipt.
+    expires_date = forms.Field(required=False)
+
+    # The transaction identifier of the original purchase.
+    # See https://developer.apple.com/documentation/appstorereceipts/original_transaction_id
+    original_transaction_id = forms.CharField()
+
+    # A unique identifier for a transaction such as a purchase, restore, or renewal.
+    # See https://developer.apple.com/documentation/appstorereceipts/transaction_id for more information
+    transaction_id = forms.CharField()
+
+    # An indicator of whether an auto-renewable subscription is in the introductory
+    # price period.
+    is_in_intro_offer_period = forms.NullBooleanField()
+
+    # An indicator of whether a subscription is in the free trial period.
+    is_trial_period = forms.NullBooleanField()
+
+    # The number of consumable products purchased. This value corresponds to the
+    # quantity property of the SKPayment object stored in the transaction's payment
+    # property. The value is usually "1" unless modified with a mutable payment.
+    # The maximum value is "10".
+    quantity = forms.IntegerField()
+
+    # A unique identifier for purchase events across devices, including subscription-renewal
+    # events. This value is the primary key for identifying subscription purchases.
+    web_order_line_item_id = forms.CharField()
+
+    def clean_original_purchase_date(self):
+        return _clean_date(self.data, "original_purchase_date")
+
+    def clean_purchase_date(self):
+        return _clean_date(self.data, "purchase_date")
+
+    def clean_expires_date(self):
+        return _clean_date(self.data, "expires_date", required=False)
+
+
+class AppleUnifiedLatestReceiptInfoForm(forms.Form):
+    """
+    A Django form to validate receipt info
+
+    See https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info
+    """
+
+    CANCELLATION_REASON_CHOICES = ((0, "Other"), (1, "Issue"))
+
+    # The time Apple customer support canceled a transaction, or the time an
+    # auto-renewable subscription plan was upgraded. This field is only present
+    # for refunded transactions.
+    cancellation_date = forms.Field(required=False)
+
+    # The reason for a refunded transaction. When a customer cancels a transaction,
+    # the App Store gives them a refund and provides a value for this key. A value of
+    # "1" indicates that the customer canceled their transaction due to an actual or
+    # perceived issue within your app. A value of "0" indicates that the transaction
+    # was canceled for another reason; for example, if the customer made the purchase
+    # accidentally.
+    cancellation_reason = forms.ChoiceField(
+        choices=CANCELLATION_REASON_CHOICES, required=False
+    )
+
+    # The time a subscription expires or when it will renew.
+    expires_date = forms.Field(required=False)
+
+    # An indicator of whether an auto-renewable subscription is in the introductory
+    # price period.
+    is_in_intro_offer_period = forms.NullBooleanField()
+
+    # An indicator of whether a subscription is in the free trial period.
+    is_trial_period = forms.NullBooleanField()
+
+    # An indicator that a subscription has been canceled due to an upgrade. This
+    # field is only present for upgrade transactions.
+    is_upgraded = forms.NullBooleanField()
+
+    # The time of the original app purchase. This value indicates the date of the
+    # subscription's initial purchase. The original purchase date applies to all
+    # product types and remains the same in all transactions for the same product
+    # ID. This value corresponds to the original transaction's transactionDate
+    # property in StoreKit.
+    original_purchase_date = forms.Field()
+
+    # The transaction identifier of the original purchase.
+    # See https://developer.apple.com/documentation/appstorereceipts/original_transaction_id
+    original_transaction_id = forms.CharField()
+
+    # The unique identifier of the product purchased. You provide this value when
+    # creating the product in App Store Connect, and it corresponds to the
+    # productIdentifier property of the SKPayment object stored in the transaction's
+    # payment property.
+    product_id = forms.CharField()
+
+    # The identifier of the subscription offer redeemed by the user. See promotional_offer_id for more information.
+    promotional_offer_id = forms.CharField(required=False)
+
+    # For consumable, non-consumable, and non-renewing subscription products, the time
+    # the App Store charged the user's account for a purchased or restored product. For
+    # auto-renewable subscriptions, the time the App Store charged the user's account
+    # for a subscription purchase or renewal after a lapse.
+    purchase_date = forms.Field()
+
+    # The number of consumable products purchased. This value corresponds to the
+    # quantity property of the SKPayment object stored in the transaction's payment
+    # property. The value is usually "1" unless modified with a mutable payment.
+    # The maximum value is "10".
+    quantity = forms.IntegerField()
+
+    # The identifier of the subscription group to which the subscription belongs. The value for this field is identical to the subscriptionGroupIdentifier property in SKProduct.
+    subscription_group_identifier = forms.CharField(required=False)
+
+    # A unique identifier for a transaction such as a purchase, restore, or renewal.
+    # See https://developer.apple.com/documentation/appstorereceipts/transaction_id for more information
+    transaction_id = forms.CharField()
+
+    # A unique identifier for purchase events across devices, including subscription-renewal
+    # events. This value is the primary key for identifying subscription purchases.
+    web_order_line_item_id = forms.CharField()
+
+    def clean_cancellation_date(self):
+        return _clean_date(self.data, "cancellation_date", required=False)
+
+    def clean_original_purchase_date(self):
+        return _clean_date(self.data, "original_purchase_date")
+
+    def clean_purchase_date(self):
+        return _clean_date(self.data, "purchase_date")
+
+    def clean_expires_date(self):
+        return _clean_date(self.data, "expires_date", required=False)
+
+
+class AppleUnifiedPendingRenewalInfoForm(forms.Form):
+    """
+    A Django form to validate a pending renewal structure in a unified receipt structure.
+
+    https://developer.apple.com/documentation/appstorereceipts/responsebody/pending_renewal_info
+    """
+
+    PRICE_CONSENT_CHOICES = ((0, "Pending"), (1, "Consented"))
+
+    # The current renewal preference for the auto-renewable subscription. The value for this key
+    # corresponds to the productIdentifier property of the product that the customer's subscription
+    # renews. This field is only present if the user downgrades or crossgrades to a subscription of
+    #   a different duration for the subsequent subscription period.
+    auto_renew_product_id = forms.CharField(required=False)
+
+    # The unique identifier of the product purchased. You provide this value when
+    # creating the product in App Store Connect, and it corresponds to the
+    # productIdentifier property of the SKPayment object stored in the transaction's
+    # payment property.
+    product_id = forms.CharField()
+
+    # The current renewal status for an auto-renewable subscription product. Note
+    # that these values are different from those of the auto_renew_status in the
+    # receipt.
+    auto_renew_status = forms.NullBooleanField()
+
+    # The reason a subscription expired. This field is only present for an expired
+    # auto-renewable subscription.
+    expiration_intent = forms.ChoiceField(
+        choices=EXPIRATION_INTENT_CHOICES, required=False
+    )
+
+    # The time at which the grace period for subscription renewals expires. This key
+    # is only present for apps that have Billing Grace Period enabled and when the
+    # user experiences a billing error at the time of renewal.
+    grace_period_expires_date = forms.Field(required=False)
+
+    # A flag that indicates Apple is attempting to renew an expired subscription
+    # automatically. This field is only present if an auto-renewable subscription
+    # is in the billing retry state.
+    is_in_billing_retry_period = forms.NullBooleanField()
+
+    # The transaction identifier of the original purchase.
+    # See https://developer.apple.com/documentation/appstorereceipts/original_transaction_id
+    original_transaction_id = forms.CharField()
+
+    # The price consent status for a subscription price increase. This field is only present
+    # if the customer was notified of the price increase. The default value is "0" and changes
+    # to "1" if the customer consents.
+    price_consent_status = forms.ChoiceField(
+        choices=PRICE_CONSENT_CHOICES, required=False
+    )
+
+    def clean_grace_period_expires_date(self):
+        return _clean_date(self.data, "grace_period_expires_date", required=False)
+
+
+class AppleUnifiedReceiptForm(forms.Form):
+    """
+    A Django form to validate a unified reciept.
+
+    https://developer.apple.com/documentation/appstoreservernotifications/unified_receipt
+    """
+
+    ENVIRONMENTS = ("Sandbox", "Production")
+    ENVIRONMENT_CHOICES = [(env, env) for env in ENVIRONMENTS]
+
+    # Specifies whether the notification is for a sandbox or a production
+    # environment.
+    environment = forms.ChoiceField(choices=ENVIRONMENT_CHOICES)
+
+    # The latest Base64-encoded transaction receipt.
+    latest_receipt = forms.CharField(required=False)
+
+    # The JSON representation of the value in latest_receipt. Note that this
+    # field is an array in the receipt but a single object in server-to-server
+    # notifications. Not sent for expired transactions.
+    latest_receipt_info = forms.Field(required=False)
+
+    pending_renewal_info = forms.Field(required=False)
+
+    # The status code, where 0 indicates that the notification is valid.
+    status = forms.IntegerField()
+
+    def clean_status(self):
+        value = self.cleaned_data["status"]
+        if value != 0:
+            raise forms.ValidationError(
+                "Invalid unified receipt status: {}".format(value)
+            )
+        return value
+
+    def clean_latest_receipt_info(self):
+        return _clean_list_of_form_data(
+            AppleUnifiedLatestReceiptInfoForm,
+            "latest_receipt_info",
+            self.cleaned_data.get("latest_receipt_info"),
+        )
+
+    def clean_pending_renewal_info(self):
+        return _clean_list_of_form_data(
+            AppleUnifiedPendingRenewalInfoForm,
+            "pending_renewal_info",
+            self.cleaned_data.get("pending_renewal_info"),
+        )
 
 
 class AppleStatusUpdateForm(forms.Form):
@@ -9,9 +374,14 @@ class AppleStatusUpdateForm(forms.Form):
     A Django form to validate the POST sent by Apple on subscription updates.
 
     See https://developer.apple.com/documentation/storekit/in-app_purchase/enabling_status_update_notifications  # noqa
+    See https://developer.apple.com/documentation/appstoreservernotifications
     """
 
     ENVIRONMENTS = ("Sandbox", "PROD")
+    ENVIRONMENT_CHOICES = [
+        (ENVIRONMENTS[0], "Sandbox"),
+        [ENVIRONMENTS[1], "Production"],
+    ]
 
     INITIAL_BUY = "INITIAL_BUY"
     CANCEL = "CANCEL"
@@ -20,6 +390,7 @@ class AppleStatusUpdateForm(forms.Form):
     DID_CHANGE_RENEWAL_STATUS = "DID_CHANGE_RENEWAL_STATUS"
     DID_FAIL_TO_RENEW = "DID_FAIL_TO_RENEW"
     DID_RECOVER = "DID_RECOVER"
+    REFUND = "REFUND"
 
     # Deprecated, use DID_RECOVER instead
     RENEWAL = "RENEWAL"
@@ -32,114 +403,105 @@ class AppleStatusUpdateForm(forms.Form):
         DID_CHANGE_RENEWAL_STATUS,
         DID_FAIL_TO_RENEW,
         DID_RECOVER,
+        REFUND,
         # Deprecated
         RENEWAL,
     )
 
+    NOTIFICATION_CHOICES = [
+        (notif, notif.replace("_", " ").title()) for notif in NOTIFICATION_TYPES
+    ]
+
     # Specifies whether the notification is for a sandbox or a production
     # environment.
-    environment = forms.ChoiceField(
-        choices=[(env, env.lower()) for env in ENVIRONMENTS]
-    )
+    environment = forms.ChoiceField(choices=ENVIRONMENT_CHOICES)
 
-    # Describes the kind of event that triggered the notification.
-    notification_type = forms.ChoiceField(
-        choices=[(notif, notif.lower()) for notif in NOTIFICATION_TYPES]
-    )
+    # The subscription event that triggered the notification.
+    notification_type = forms.ChoiceField(choices=NOTIFICATION_CHOICES)
 
-    # This value is the same as the shared secret you POST when validating
-    # receipts.
+    # The same value as the shared secret you submit in the password field
+    # of the requestBody when validating receipts.
     password = forms.CharField()
 
-    # This value is the same as the Original Transaction Identifier in the
-    # receipt. You can use this value to relate multiple iOS 6-style transaction
-    # receipts for an individual customer's subscription.
-    original_transaction_id = forms.CharField(required=False)
+    # A string that contains the app bundle ID.
+    bid = forms.CharField()
 
-    # The time and date that a transaction was cancelled by Apple customer
-    # support. Posted only if the notification_type is CANCEL.
-    cancellation_date = forms.CharField(required=False)
+    # A string that contains the app bundle version.
+    bvrs = forms.CharField()
 
-    # The primary key for identifying a subscription purchase. Posted only if
-    # the notification_type is CANCEL.
-    web_order_line_item_id = forms.CharField(required=False)
+    # An identifier that App Store Connect generates and the App Store uses to
+    # uniquely identify the auto-renewable subscription that the user's
+    # subscription renews. Treat this value as a 64-bit integer.
+    # TODO(streeter) - convert to an integer?
+    auto_renew_adam_id = forms.CharField(required=False, max_length=64)
 
-    # The base-64 encoded transaction receipt for the most recent renewal
-    # transaction. Posted only if the notification_type is RENEWAL or
-    # INTERACTIVE_RENEWAL, and only if the renewal is successful.
-    latest_receipt = forms.CharField(required=False)
-
-    # The JSON representation of the receipt for the most recent renewal.
-    # Posted only if renewal is successful. Not posted for notification_type
-    # CANCEL.
-    latest_receipt_info = forms.Field(required=False)
-
-    # The base-64 encoded transaction receipt for the most recent renewal
-    # transaction. Posted only if the subscription expired.
-    latest_expired_receipt = forms.CharField(required=False)
-
-    # The JSON representation of the receipt for the most recent renewal
-    # transaction. Posted only if the notification_type is RENEWAL or CANCEL or
-    # if renewal failed and subscription expired.
-    latest_expired_receipt_info = forms.Field(required=False)
-
-    # A Boolean value indicated by strings "true" or "false". This is the same
-    # as the auto renew status in the receipt.
-    auto_renew_status = forms.NullBooleanField()
-
-    # The current renewal preference for the auto-renewable subscription. This
-    # is the Apple ID of the product.
-    auto_renew_adam_id = forms.CharField(required=False)
-
-    # This is the same as the Subscription Auto Renew Preference in the receipt.
+    # The product identifier of the auto-renewable subscription that the user's
+    # subscription renews.
     auto_renew_product_id = forms.CharField(required=False)
 
-    # This is the same as the Subscription Expiration Intent in the receipt.
-    # Posted only if notification_type is RENEWAL or INTERACTIVE_RENEWAL.
-    expiration_intent = forms.CharField(required=False)
+    # The current renewal status for an auto-renewable subscription product. Note
+    # that these values are different from those of the auto_renew_status in the
+    # receipt.
+    auto_renew_status = forms.NullBooleanField()
 
-    def _clean_receipt(self, name):
-        receipt = self.cleaned_data.get(name)
-        if not receipt:
-            return None
+    # The time at which the renewal status for an auto-renewable subscription was
+    # turned on or off.
+    auto_renew_status_change_date = forms.Field(required=False)
 
-        try:
-            # Ensure the receipt can be base 64 decoded
-            base64.b64decode(receipt)
-        except TypeError:
-            raise forms.ValidationError("Unable to decode {}".format(name))
-        return receipt
+    # The reason a subscription expired. This field is only present for an expired
+    # auto-renewable subscription.
+    expiration_intent = forms.ChoiceField(
+        choices=EXPIRATION_INTENT_CHOICES, required=False
+    )
 
-    def _clean_receipt_info(self, name):
-        info = self.cleaned_data.get(name)
-        if not info:
-            return None
+    # The latest Base64-encoded transaction receipt. This field appears in the
+    # notification instead of latest_receipt for expired transactions.
+    latest_expired_receipt = forms.CharField(required=False)
 
-        # The following is to support py2 and py3
-        # https://stackoverflow.com/a/22679982
-        try:
-            basestring  # noqa
-        except NameError:
-            basestring = (str, bytes)
+    # The JSON representation of the value in latest_expired_receipt. This appears
+    # in the notification instead of latest_receipt_info for expired transactions.
+    latest_expired_receipt_info = forms.Field(required=False)
 
-        if not isinstance(info, basestring):
-            return info
+    # The latest Base64-encoded transaction receipt.
+    latest_receipt = forms.CharField(required=False)
 
-        try:
-            return json.loads(info)
-        except ValueError as e:
-            raise forms.ValidationError(
-                'Unable to parse {} "{}": {}'.format(name, info, e)
-            )
+    # The JSON representation of the value in latest_receipt. Note that this
+    # field is an array in the receipt but a single object in server-to-server
+    # notifications. Not sent for expired transactions.
+    latest_receipt_info = forms.Field(required=False)
+
+    # An object that contains information about the most recent in-app purchase
+    # transactions for the app.
+    unified_receipt = forms.Field(required=False)
+
+    def clean_auto_renew_status_change_date(self):
+        return _clean_date(self.data, "auto_renew_status_change_date", required=False)
 
     def clean_latest_receipt(self):
-        return self._clean_receipt("latest_receipt")
+        return _clean_receipt("latest_receipt", self.cleaned_data.get("latest_receipt"))
 
     def clean_latest_receipt_info(self):
-        return self._clean_receipt_info("latest_receipt_info")
+        return _clean_form_data(
+            AppleLatestReceiptInfoForm,
+            "latest_receipt_info",
+            self.cleaned_data.get("latest_receipt_info"),
+        )
 
     def clean_latest_expired_receipt(self):
-        return self._clean_receipt("latest_expired_receipt")
+        return _clean_receipt(
+            "latest_expired_receipt", self.cleaned_data.get("latest_expired_receipt")
+        )
 
     def clean_latest_expired_receipt_info(self):
-        return self._clean_receipt_info("latest_expired_receipt_info")
+        return _clean_form_data(
+            AppleLatestReceiptInfoForm,
+            "latest_receipt_info",
+            self.cleaned_data.get("latest_receipt_info"),
+        )
+
+    def clean_unified_receipt(self):
+        return _clean_form_data(
+            AppleUnifiedReceiptForm,
+            "unified_receipt",
+            self.cleaned_data.get("unified_receipt"),
+        )

--- a/iap/settings.py
+++ b/iap/settings.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-CA_FILE = settings.IAP_SETTINGS["CA_FILE"]
+TRUSTED_ROOT_FILE = settings.IAP_SETTINGS["TRUSTED_ROOT_FILE"]
 
 IAP_SHARED_SECRET = settings.IAP_SETTINGS.get("SHARED_SECRET")
 

--- a/iap/widgets.py
+++ b/iap/widgets.py
@@ -1,0 +1,20 @@
+from django.forms.widgets import NullBooleanSelect
+
+
+class IAPNullBooleanSelect(NullBooleanSelect):
+    """
+    A Select Widget intended to be used with NullBooleanField.
+    """
+
+    def value_from_datadict(self, data, files, name):
+        value = data.get(name)
+        return {
+            "2": True,
+            True: True,
+            "True": True,
+            "true": True,
+            "3": False,
+            "False": False,
+            "false": False,
+            False: False,
+        }.get(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 # For error codes, see http://pep8.readthedocs.org/en/latest/intro.html#error-codes
-ignore = W503
+ignore = W503,E501
 exclude = .git,__pycache__,build,dist,venv
 # From black
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ setup(
     install_requires=[
         "Django>=1.7",
         "pytz",
+        "asn1crypto",
         "pyopenssl>=17.0.0",
-        "pyasn1",
-        "pyasn1_modules",
         "requests",
     ],
     extras_require={"test": ["pytest", "pytest-django", "responses", "flake8"]},

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     package_dir={"iap": "iap"},
     install_requires=[
         "Django>=1.7",
+        "pytz",
         "pyopenssl>=17.0.0",
         "pyasn1",
         "pyasn1_modules",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=["iap"],
     package_dir={"iap": "iap"},
     install_requires=[
-        "Django>=1.7",
+        "Django>=1.9",
         "pytz",
         "asn1crypto",
         "pyopenssl>=17.0.0",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,6 +13,14 @@ IAP_SETTINGS = {
 }
 
 if not os.path.isfile(TRUSTED_ROOT_FILE):
-    trusted_root_data = urllib.urlretrieve(
-        "https://www.apple.com/appleca/AppleIncRootCertificate.cer", TRUSTED_ROOT_FILE
-    )
+    try:
+        trusted_root_data = urllib.urlretrieve(
+            "https://www.apple.com/appleca/AppleIncRootCertificate.cer",
+            TRUSTED_ROOT_FILE,
+        )
+    except AttributeError:
+        # Python 3
+        trusted_root_data = urllib.request.urlretrieve(
+            "https://www.apple.com/appleca/AppleIncRootCertificate.cer",
+            TRUSTED_ROOT_FILE,
+        )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,16 +1,18 @@
 import os
 import urllib
 
-CA_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "apple_root.pem")
+TRUSTED_ROOT_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "AppleIncRootCertificate.cer"
+)
 
 SECRET_KEY = "notsecr3t"
 
 IAP_SETTINGS = {
-    "CA_FILE": CA_FILE,
+    "TRUSTED_ROOT_FILE": TRUSTED_ROOT_FILE,
     "PRODUCTION_BUNDLE_ID": "com.educreations.ios.Educreations",
 }
 
-if not os.path.isfile(CA_FILE):
+if not os.path.isfile(TRUSTED_ROOT_FILE):
     trusted_root_data = urllib.urlretrieve(
-        "https://www.apple.com/appleca/AppleIncRootCertificate.cer", CA_FILE
+        "https://www.apple.com/appleca/AppleIncRootCertificate.cer", TRUSTED_ROOT_FILE
     )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,10 @@
 import os
-import urllib
+
+try:
+    # Python 3
+    import urllib.request as urllib
+except ImportError:
+    import urllib
 
 TRUSTED_ROOT_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "AppleIncRootCertificate.cer"
@@ -13,14 +18,6 @@ IAP_SETTINGS = {
 }
 
 if not os.path.isfile(TRUSTED_ROOT_FILE):
-    try:
-        trusted_root_data = urllib.urlretrieve(
-            "https://www.apple.com/appleca/AppleIncRootCertificate.cer",
-            TRUSTED_ROOT_FILE,
-        )
-    except AttributeError:
-        # Python 3
-        trusted_root_data = urllib.request.urlretrieve(
-            "https://www.apple.com/appleca/AppleIncRootCertificate.cer",
-            TRUSTED_ROOT_FILE,
-        )
+    trusted_root_data = urllib.urlretrieve(
+        "https://www.apple.com/appleca/AppleIncRootCertificate.cer", TRUSTED_ROOT_FILE,
+    )

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,7 +2,6 @@ import datetime
 
 from iap.forms import (
     AppleLatestReceiptInfoForm,
-    AppleUnifiedLatestReceiptInfoForm,
     AppleUnifiedPendingRenewalInfoForm,
     AppleUnifiedReceiptForm,
     AppleStatusUpdateForm,
@@ -43,8 +42,8 @@ def test_valid_latest_receipt_info_form():
     assert isinstance(form.cleaned_data["expires_date"], datetime.datetime)
     assert isinstance(form.cleaned_data["original_purchase_date"], datetime.datetime)
     assert isinstance(form.cleaned_data["purchase_date"], datetime.datetime)
-    assert form.cleaned_data["is_in_intro_offer_period"] == False
-    assert form.cleaned_data["is_trial_period"] == False
+    assert not form.cleaned_data["is_in_intro_offer_period"]
+    assert not form.cleaned_data["is_trial_period"]
     assert form.cleaned_data["quantity"] == 1
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,176 @@
+import datetime
+
+from iap.forms import (
+    AppleLatestReceiptInfoForm,
+    AppleUnifiedLatestReceiptInfoForm,
+    AppleUnifiedPendingRenewalInfoForm,
+    AppleUnifiedReceiptForm,
+    AppleStatusUpdateForm,
+)
+
+
+def test_valid_latest_receipt_info_form():
+    # An example response from Apple
+    data = {
+        "app_item_id": "478617061",
+        "bid": "com.educreations.ios.Educreations",
+        "bvrs": "10703",
+        "expires_date": "1595808159000",
+        "expires_date_formatted": "2020-07-27 00:02:39 Etc/GMT",
+        "expires_date_formatted_pst": "2020-07-26 17:02:39 America/Los_Angeles",
+        "is_in_intro_offer_period": "false",
+        "is_trial_period": "false",
+        "item_id": "958706035",
+        "original_purchase_date": "2020-06-27 00:02:42 Etc/GMT",
+        "original_purchase_date_ms": "1593216162000",
+        "original_purchase_date_pst": "2020-06-26 17:02:42 America/Los_Angeles",
+        "original_transaction_id": "260000726888107",
+        "product_id": "com.educreations.proteacher.1month",
+        "purchase_date": "2020-06-27 00:02:39 Etc/GMT",
+        "purchase_date_ms": "1593216159000",
+        "purchase_date_pst": "2020-06-26 17:02:39 America/Los_Angeles",
+        "quantity": "1",
+        "subscription_group_identifier": "19974122",
+        "transaction_id": "260000726888107",
+        "unique_identifier": "00008027-0011495C1413002E",
+        "unique_vendor_identifier": "D58CBBCE-A3AA-4E93-AC24-50049702C82F",
+        "version_external_identifier": "836345400",
+        "web_order_line_item_id": "260000276820002",
+    }
+
+    form = AppleLatestReceiptInfoForm(data)
+    assert form.is_valid(), form.errors.as_data()
+    assert isinstance(form.cleaned_data["expires_date"], datetime.datetime)
+    assert isinstance(form.cleaned_data["original_purchase_date"], datetime.datetime)
+    assert isinstance(form.cleaned_data["purchase_date"], datetime.datetime)
+    assert form.cleaned_data["is_in_intro_offer_period"] == False
+    assert form.cleaned_data["is_trial_period"] == False
+    assert form.cleaned_data["quantity"] == 1
+
+
+def test_valid_unified_pending_renewal_info_form():
+    data = {
+        "auto_renew_product_id": "com.educreations.proteacher.1month",
+        "auto_renew_status": "1",
+        "original_transaction_id": "260000726888107",
+        "product_id": "com.educreations.proteacher.1month",
+    }
+
+    form = AppleUnifiedPendingRenewalInfoForm(data)
+    assert form.is_valid(), form.errors.as_data()
+
+
+def test_valid_unified_receipt_form():
+    data = {
+        "environment": "Production",
+        "latest_receipt": "MIIUDwYJKoZIhvcNAQcCoIIUADCCE/wCAQExCzAJBgUrDgMCGgUAMIIDsAYJKoZIhvcNAQcBoIIDoQSCA50xggOZMAoCARMCAQEEAgwAMAoCARQCAQEEAgwAMAsCARkCAQEEAwIBAzAMAgEOAgEBBAQCAgDDMA0CAQsCAQEEBQIDCiZiMA0CAQ0CAQEEBQIDAf3FMA4CAQECAQEEBgIEHIcd5TAOAgEJAgEBBAYCBFAyNTMwDgIBCgIBAQQGFgRub25lMA4CARACAQEEBgIEMdmeODAPAgEDAgEBBAcMBTEwNzAzMBQCAQACAQEEDAwKUHJvZHVjdGlvbjAYAgEEAgECBBDd+TETKHYyspHAG900qpy6MBwCAQUCAQEEFI51s4zGAv0zrOcof3zwu7IfcyZcMB4CAQgCAQEEFhYUMjAyMC0wNi0yN1QwMDowMjozOVowHgIBDAIBAQQWFhQyMDIwLTA2LTI3VDAwOjAzOjAyWjAeAgESAgEBBBYWFDIwMjAtMDYtMjdUMDA6MDI6MzlaMCsCAQICAQEEIwwhY29tLmVkdWNyZWF0aW9ucy5pb3MuRWR1Y3JlYXRpb25zMD4CAQcCAQEENqX4lK25SOGmGE6GgxzGZnjbxkkqVM+Xw1lAwNzh7K6ms4g8nGjZzl0OOTVIorPGEgx9VVHK1jBGAgEGAgEBBD49th2SFq4KVzxazvS7VTExN1XCPz0B2N7rxjc+xtr2cYeuVibJevdYBx3vHkzJonS1GuoQty5R/l8qunTGpzCCAZACARECAQEEggGGMYIBgjALAgIGrQIBAQQCDAAwCwICBrACAQEEAhYAMAsCAgayAgEBBAIMADALAgIGswIBAQQCDAAwCwICBrQCAQEEAgwAMAsCAga1AgEBBAIMADALAgIGtgIBAQQCDAAwDAICBqUCAQEEAwIBATAMAgIGqwIBAQQDAgEDMAwCAgaxAgEBBAMCAQAwDAICBrcCAQEEAwIBADAPAgIGrgIBAQQGAgQ5JLFzMBICAgavAgEBBAkCBwDseAgkMCIwGgICBqcCAQEEEQwPMjYwMDAwNzI2ODg4MTA3MBoCAgapAgEBBBEMDzI2MDAwMDcyNjg4ODEwNzAfAgIGqAIBAQQWFhQyMDIwLTA2LTI3VDAwOjAyOjM5WjAfAgIGqgIBAQQWFhQyMDIwLTA2LTI3VDAwOjAyOjQyWjAfAgIGrAIBAQQWFhQyMDIwLTA3LTI3VDAwOjAyOjM5WjAtAgIGpgIBAQQkDCJjb20uZWR1Y3JlYXRpb25zLnByb3RlYWNoZXIuMW1vbnRooIIOZTCCBXwwggRkoAMCAQICCA7rV4fnngmNMA0GCSqGSIb3DQEBBQUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECgwKQXBwbGUgSW5jLjEsMCoGA1UECwwjQXBwbGUgV29ybGR3aWRlIERldmVsb3BlciBSZWxhdGlvbnMxRDBCBgNVBAMMO0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTE1MTExMzAyMTUwOVoXDTIzMDIwNzIxNDg0N1owgYkxNzA1BgNVBAMMLk1hYyBBcHAgU3RvcmUgYW5kIGlUdW5lcyBTdG9yZSBSZWNlaXB0IFNpZ25pbmcxLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zMRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXPgf0looFb1oftI9ozHI7iI8ClxCbLPcaf7EoNVYb/pALXl8o5VG19f7JUGJ3ELFJxjmR7gs6JuknWCOW0iHHPP1tGLsbEHbgDqViiBD4heNXbt9COEo2DTFsqaDeTwvK9HsTSoQxKWFKrEuPt3R+YFZA1LcLMEsqNSIH3WHhUa+iMMTYfSgYMR1TzN5C4spKJfV+khUrhwJzguqS7gpdj9CuTwf0+b8rB9Typj1IawCUKdg7e/pn+/8Jr9VterHNRSQhWicxDkMyOgQLQoJe2XLGhaWmHkBBoJiY5uB0Qc7AKXcVz0N92O9gt2Yge4+wHz+KO0NP6JlWB7+IDSSMCAwEAAaOCAdcwggHTMD8GCCsGAQUFBwEBBDMwMTAvBggrBgEFBQcwAYYjaHR0cDovL29jc3AuYXBwbGUuY29tL29jc3AwMy13d2RyMDQwHQYDVR0OBBYEFJGknPzEdrefoIr0TfWPNl3tKwSFMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUiCcXCam2GGCL7Ou69kdZxVJUo7cwggEeBgNVHSAEggEVMIIBETCCAQ0GCiqGSIb3Y2QFBgEwgf4wgcMGCCsGAQUFBwICMIG2DIGzUmVsaWFuY2Ugb24gdGhpcyBjZXJ0aWZpY2F0ZSBieSBhbnkgcGFydHkgYXNzdW1lcyBhY2NlcHRhbmNlIG9mIHRoZSB0aGVuIGFwcGxpY2FibGUgc3RhbmRhcmQgdGVybXMgYW5kIGNvbmRpdGlvbnMgb2YgdXNlLCBjZXJ0aWZpY2F0ZSBwb2xpY3kgYW5kIGNlcnRpZmljYXRpb24gcHJhY3RpY2Ugc3RhdGVtZW50cy4wNgYIKwYBBQUHAgEWKmh0dHA6Ly93d3cuYXBwbGUuY29tL2NlcnRpZmljYXRlYXV0aG9yaXR5LzAOBgNVHQ8BAf8EBAMCB4AwEAYKKoZIhvdjZAYLAQQCBQAwDQYJKoZIhvcNAQEFBQADggEBAA2mG9MuPeNbKwduQpZs0+iMQzCCX+Bc0Y2+vQ+9GvwlktuMhcOAWd/j4tcuBRSsDdu2uP78NS58y60Xa45/H+R3ubFnlbQTXqYZhnb4WiCV52OMD3P86O3GH66Z+GVIXKDgKDrAEDctuaAEOR9zucgF/fLefxoqKm4rAfygIFzZ630npjP49ZjgvkTbsUxn/G4KT8niBqjSl/OnjmtRolqEdWXRFgRi48Ff9Qipz2jZkgDJwYyz+I0AZLpYYMB8r491ymm5WyrWHWhumEL1TKc3GZvMOxx6GUPzo22/SGAGDDaSK+zeGLUR2i0j0I78oGmcFxuegHs5R0UwYS/HE6gwggQiMIIDCqADAgECAggB3rzEOW2gEDANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwHhcNMTMwMjA3MjE0ODQ3WhcNMjMwMjA3MjE0ODQ3WjCBljELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zMUQwQgYDVQQDDDtBcHBsZSBXb3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9ucyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMo4VKbLVqrIJDlI6Yzu7F+4fyaRvDRTes58Y4Bhd2RepQcjtjn+UC0VVlhwLX7EbsFKhT4v8N6EGqFXya97GP9q+hUSSRUIGayq2yoy7ZZjaFIVPYyK7L9rGJXgA6wBfZcFZ84OhZU3au0Jtq5nzVFkn8Zc0bxXbmc1gHY2pIeBbjiP2CsVTnsl2Fq/ToPBjdKT1RpxtWCcnTNOVfkSWAyGuBYNweV3RY1QSLorLeSUheHoxJ3GaKWwo/xnfnC6AllLd0KRObn1zeFM78A7SIym5SFd/Wpqu6cWNWDS5q3zRinJ6MOL6XnAamFnFbLw/eVovGJfbs+Z3e8bY/6SZasCAwEAAaOBpjCBozAdBgNVHQ4EFgQUiCcXCam2GGCL7Ou69kdZxVJUo7cwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBQr0GlHlHYJ/vRrjS5ApvdHTX8IXjAuBgNVHR8EJzAlMCOgIaAfhh1odHRwOi8vY3JsLmFwcGxlLmNvbS9yb290LmNybDAOBgNVHQ8BAf8EBAMCAYYwEAYKKoZIhvdjZAYCAQQCBQAwDQYJKoZIhvcNAQEFBQADggEBAE/P71m+LPWybC+P7hOHMugFNahui33JaQy52Re8dyzUZ+L9mm06WVzfgwG9sq4qYXKxr83DRTCPo4MNzh1HtPGTiqN0m6TDmHKHOz6vRQuSVLkyu5AYU2sKThC22R1QbCGAColOV4xrWzw9pv3e9w0jHQtKJoc/upGSTKQZEhltV/V6WId7aIrkhoxK6+JJFKql3VUAqa67SzCu4aCxvCmA5gl35b40ogHKf9ziCuY7uLvsumKV8wVjQYLNDzsdTJWk26v5yZXpT+RN5yaZgem8+bQp0gF6ZuEujPYhisX4eOGBrr/TkJ2prfOv/TgalmcwHFGlXOxxioK0bA8MFR8wggS7MIIDo6ADAgECAgECMA0GCSqGSIb3DQEBBQUAMGIxCzAJBgNVBAYTAlVTMRMwEQYDVQQKEwpBcHBsZSBJbmMuMSYwJAYDVQQLEx1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTEWMBQGA1UEAxMNQXBwbGUgUm9vdCBDQTAeFw0wNjA0MjUyMTQwMzZaFw0zNTAyMDkyMTQwMzZaMGIxCzAJBgNVBAYTAlVTMRMwEQYDVQQKEwpBcHBsZSBJbmMuMSYwJAYDVQQLEx1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTEWMBQGA1UEAxMNQXBwbGUgUm9vdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOSRqQkfkdseR1DrBe1eeYQt6zaiV0xV7IsZid75S2z1B6siMALoGD74UAnTf0GomPnRymacJGsR0KO75Bsqwx+VnnoMpEeLW9QWNzPLxA9NzhRp0ckZcvVdDtV/X5vyJQO6VY9NXQ3xZDUjFUsVWR2zlPf2nJ7PULrBWFBnjwi0IPfLrCwgb3C2PwEwjLdDzw+dPfMrSSgayP7OtbkO2V4c1ss9tTqt9A8OAJILsSEWLnTVPA3bYharo3GSR1NVwa8vQbP4++NwzeajTEV+H0xrUJZBicR0YgsQg0GHM4qBsTBY7FoEMoxos48d3mVz/2deZbxJ2HafMxRloXeUyS0CAwEAAaOCAXowggF2MA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQr0GlHlHYJ/vRrjS5ApvdHTX8IXjAfBgNVHSMEGDAWgBQr0GlHlHYJ/vRrjS5ApvdHTX8IXjCCAREGA1UdIASCAQgwggEEMIIBAAYJKoZIhvdjZAUBMIHyMCoGCCsGAQUFBwIBFh5odHRwczovL3d3dy5hcHBsZS5jb20vYXBwbGVjYS8wgcMGCCsGAQUFBwICMIG2GoGzUmVsaWFuY2Ugb24gdGhpcyBjZXJ0aWZpY2F0ZSBieSBhbnkgcGFydHkgYXNzdW1lcyBhY2NlcHRhbmNlIG9mIHRoZSB0aGVuIGFwcGxpY2FibGUgc3RhbmRhcmQgdGVybXMgYW5kIGNvbmRpdGlvbnMgb2YgdXNlLCBjZXJ0aWZpY2F0ZSBwb2xpY3kgYW5kIGNlcnRpZmljYXRpb24gcHJhY3RpY2Ugc3RhdGVtZW50cy4wDQYJKoZIhvcNAQEFBQADggEBAFw2mUwteLftjJvc83eb8nbSdzBPwR+Fg4UbmT1HN/Kpm0COLNSxkBLYvvRzm+7SZA/LeU802KI++Xj/a8gH7H05g4tTINM4xLG/mk8Ka/8r/FmnBQl8F0BWER5007eLIztHo9VvJOLr0bdw3w9F4SfK8W147ee1Fxeo3H4iNcol1dkP1mvUoiQjEfehrI9zgWDGG1sJL5Ky+ERI8GA4nhX1PSZnIIozavcNgs/e66Mv+VNqW2TAYzN39zoHLFbr2g8hDtq6cxlPtdk2f8GHVdmnmbkyQvvY1XGefqFStxu9k0IkEirHDx22TZxeY8hLgBdQqorV2uT80AkHN7B1dSExggHLMIIBxwIBATCBozCBljELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zMUQwQgYDVQQDDDtBcHBsZSBXb3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9ucyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eQIIDutXh+eeCY0wCQYFKw4DAhoFADANBgkqhkiG9w0BAQEFAASCAQCdB1UwJ9Fe91rxbACjhUY80XOG4J+dmgoIbE+k0zjwu/UimWPyRTd46rpI69IQHYOqpkDsy6JGOjp3lywHV2FXCIxVxp1D3+nTDUcEb3ApNWPrV8IpHzy+kcj79qcBeDYdPe5vE2aDXFMn76Nx5SJ29wzu9IYxSnQbw/zhoReFV6mVVGiEn3FSS4WRs5PXshkZb3PHYHQRpJCMZyyzrcq63DRxqQRYwyfGG8wa/cq9KkNEUR5oJZsw+r9b+CH6cLtED0ZjRe1ZxaUbd12IgNtkLgmRTCQNPyGFrd5PEjDhiE9AzdyPRkpYg020nYmfUZ4ABuuztMlozRD31jjSVLOA",
+        "latest_receipt_info": [
+            {
+                "expires_date": "2020-07-27 00:02:39 Etc/GMT",
+                "expires_date_ms": "1595808159000",
+                "expires_date_pst": "2020-07-26 17:02:39 America/Los_Angeles",
+                "is_in_intro_offer_period": "false",
+                "is_trial_period": "false",
+                "original_purchase_date": "2020-06-27 00:02:42 Etc/GMT",
+                "original_purchase_date_ms": "1593216162000",
+                "original_purchase_date_pst": "2020-06-26 17:02:42 America/Los_Angeles",
+                "original_transaction_id": "260000726888107",
+                "product_id": "com.educreations.proteacher.1month",
+                "purchase_date": "2020-06-27 00:02:39 Etc/GMT",
+                "purchase_date_ms": "1593216159000",
+                "purchase_date_pst": "2020-06-26 17:02:39 America/Los_Angeles",
+                "quantity": "1",
+                "subscription_group_identifier": "19974122",
+                "transaction_id": "260000726888107",
+                "web_order_line_item_id": "260000276820002",
+            }
+        ],
+        "pending_renewal_info": [
+            {
+                "auto_renew_product_id": "com.educreations.proteacher.1month",
+                "auto_renew_status": "1",
+                "original_transaction_id": "260000726888107",
+                "product_id": "com.educreations.proteacher.1month",
+            }
+        ],
+        "status": 0,
+    }
+
+    form = AppleUnifiedReceiptForm(data)
+    assert form.is_valid(), form.errors.as_data()
+
+
+def test_apple_status_update_form():
+    data = {
+        "auto_renew_product_id": "com.educreations.proteacher.1month",
+        "auto_renew_status": "true",
+        "bid": "com.educreations.ios.Educreations",
+        "bvrs": "10703",
+        "environment": "PROD",
+        "latest_receipt": "ewoJInNpZ25hdHVyZSIgPSAiQXgrTlZkKzY1aUo1WHliZTFETGtvVWU4MjlEc0c1cGtleGdYY0J2RFBrOHFFSkpxc005b1JRRFA4RUtiZnkxNklEQTJqRWxqRTRZN1UyQ2lzemN2UGp1aTdINU4yZGhJVVpYSXFSOGdDUXIrc0tNSkZjYStJYk5IeU1hS2d6SnhGYTh0ZjAxR0dUcHZ1VmxrK1VTaG95dklnM3JvMGo1aFBOckJWR2grSVdiTkI4UHpQbDlQODRRL1Y0VlAzY3AwelBSRisvZm9KLzl5T0tacWx1ZVdzTmwzVGY3UTI4NFZaVXhvVzViQUVjMzlPbEU0eVh2RzdKMTZZbFBJbUVUYW14eE5nT0RVVkltOHR6ZmJxdk1vMHZ2VW9Td3JtMCtqNGZwKzJYcndnTFZBaHRpVE5oaGMvTUIzVFVveEtEckJCalBCVFpqNy9vOHJxaW56Mi8vR29BNEFBQVdBTUlJRmZEQ0NCR1NnQXdJQkFnSUlEdXRYaCtlZUNZMHdEUVlKS29aSWh2Y05BUUVGQlFBd2daWXhDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFLREFwQmNIQnNaU0JKYm1NdU1Td3dLZ1lEVlFRTERDTkJjSEJzWlNCWGIzSnNaSGRwWkdVZ1JHVjJaV3h2Y0dWeUlGSmxiR0YwYVc5dWN6RkVNRUlHQTFVRUF3dzdRWEJ3YkdVZ1YyOXliR1IzYVdSbElFUmxkbVZzYjNCbGNpQlNaV3hoZEdsdmJuTWdRMlZ5ZEdsbWFXTmhkR2x2YmlCQmRYUm9iM0pwZEhrd0hoY05NVFV4TVRFek1ESXhOVEE1V2hjTk1qTXdNakEzTWpFME9EUTNXakNCaVRFM01EVUdBMVVFQXd3dVRXRmpJRUZ3Y0NCVGRHOXlaU0JoYm1RZ2FWUjFibVZ6SUZOMGIzSmxJRkpsWTJWcGNIUWdVMmxuYm1sdVp6RXNNQ29HQTFVRUN3d2pRWEJ3YkdVZ1YyOXliR1IzYVdSbElFUmxkbVZzYjNCbGNpQlNaV3hoZEdsdmJuTXhFekFSQmdOVkJBb01Da0Z3Y0d4bElFbHVZeTR4Q3pBSkJnTlZCQVlUQWxWVE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBcGMrQi9TV2lnVnZXaCswajJqTWNqdUlqd0tYRUpzczl4cC9zU2cxVmh2K2tBdGVYeWpsVWJYMS9zbFFZbmNRc1VuR09aSHVDem9tNlNkWUk1YlNJY2M4L1cwWXV4c1FkdUFPcFdLSUVQaUY0MWR1MzBJNFNqWU5NV3lwb041UEM4cjBleE5LaERFcFlVcXNTNCszZEg1Z1ZrRFV0d3N3U3lvMUlnZmRZZUZScjZJd3hOaDlLQmd4SFZQTTNrTGl5a29sOVg2U0ZTdUhBbk9DNnBMdUNsMlAwSzVQQi9UNXZ5c0gxUEttUFVockFKUXAyRHQ3K21mNy93bXYxVzE2c2MxRkpDRmFKekVPUXpJNkJBdENnbDdaY3NhRnBhWWVRRUdnbUpqbTRIUkJ6c0FwZHhYUFEzM1k3MkMzWmlCN2o3QWZQNG83UTAvb21WWUh2NGdOSkl3SURBUUFCbzRJQjF6Q0NBZE13UHdZSUt3WUJCUVVIQVFFRU16QXhNQzhHQ0NzR0FRVUZCekFCaGlOb2RIUndPaTh2YjJOemNDNWhjSEJzWlM1amIyMHZiMk56Y0RBekxYZDNaSEl3TkRBZEJnTlZIUTRFRmdRVWthU2MvTVIydDUrZ2l2Uk45WTgyWGUwckJJVXdEQVlEVlIwVEFRSC9CQUl3QURBZkJnTlZIU01FR0RBV2dCU0lKeGNKcWJZWVlJdnM2N3IyUjFuRlVsU2p0ekNDQVI0R0ExVWRJQVNDQVJVd2dnRVJNSUlCRFFZS0tvWklodmRqWkFVR0FUQ0IvakNCd3dZSUt3WUJCUVVIQWdJd2diWU1nYk5TWld4cFlXNWpaU0J2YmlCMGFHbHpJR05sY25ScFptbGpZWFJsSUdKNUlHRnVlU0J3WVhKMGVTQmhjM04xYldWeklHRmpZMlZ3ZEdGdVkyVWdiMllnZEdobElIUm9aVzRnWVhCd2JHbGpZV0pzWlNCemRHRnVaR0Z5WkNCMFpYSnRjeUJoYm1RZ1kyOXVaR2wwYVc5dWN5QnZaaUIxYzJVc0lHTmxjblJwWm1sallYUmxJSEJ2YkdsamVTQmhibVFnWTJWeWRHbG1hV05oZEdsdmJpQndjbUZqZEdsalpTQnpkR0YwWlcxbGJuUnpMakEyQmdnckJnRUZCUWNDQVJZcWFIUjBjRG92TDNkM2R5NWhjSEJzWlM1amIyMHZZMlZ5ZEdsbWFXTmhkR1ZoZFhSb2IzSnBkSGt2TUE0R0ExVWREd0VCL3dRRUF3SUhnREFRQmdvcWhraUc5Mk5rQmdzQkJBSUZBREFOQmdrcWhraUc5dzBCQVFVRkFBT0NBUUVBRGFZYjB5NDk0MXNyQjI1Q2xtelQ2SXhETUlKZjRGelJqYjY5RDcwYS9DV1MyNHlGdzRCWjMrUGkxeTRGRkt3TjI3YTQvdncxTG56THJSZHJqbjhmNUhlNXNXZVZ0Qk5lcGhtR2R2aGFJSlhuWTR3UGMvem83Y1lmcnBuNFpVaGNvT0FvT3NBUU55MjVvQVE1SDNPNXlBWDk4dDUvR2lvcWJpc0IvS0FnWE5ucmZTZW1NL2oxbU9DK1JOdXhUR2Y4YmdwUHllSUdxTktYODZlT2ExR2lXb1IxWmRFV0JHTGp3Vi8xQ0tuUGFObVNBTW5CakxQNGpRQmt1bGhnd0h5dmozWEthYmxiS3RZZGFHNllRdlZNcHpjWm04dzdISG9aUS9PamJiOUlZQVlNTnBJcjdONFl0UkhhTFNQUWp2eWdhWndYRzU2QWV6bEhSVEJoTDhjVHFBPT0iOwoJInB1cmNoYXNlLWluZm8iID0gImV3b0pJbTl5YVdkcGJtRnNMWEIxY21Ob1lYTmxMV1JoZEdVdGNITjBJaUE5SUNJeU1ESXdMVEEyTFRJMklERTNPakF5T2pReUlFRnRaWEpwWTJFdlRHOXpYMEZ1WjJWc1pYTWlPd29KSW5GMVlXNTBhWFI1SWlBOUlDSXhJanNLQ1NKemRXSnpZM0pwY0hScGIyNHRaM0p2ZFhBdGFXUmxiblJwWm1sbGNpSWdQU0FpTVRrNU56UXhNaklpT3dvSkluVnVhWEYxWlMxMlpXNWtiM0l0YVdSbGJuUnBabWxsY2lJZ1BTQWlSRFU0UTBKQ1EwVXRRVE5CUVMwMFJUa3pMVUZETWpRdE5UQXdORGszTURKRE9ESkdJanNLQ1NKdmNtbG5hVzVoYkMxd2RYSmphR0Z6WlMxa1lYUmxMVzF6SWlBOUlDSXhOVGt6TWpFMk1UWXlNREF3SWpzS0NTSmxlSEJwY21WekxXUmhkR1V0Wm05eWJXRjBkR1ZrSWlBOUlDSXlNREl3TFRBM0xUSTNJREF3T2pBeU9qTTVJRVYwWXk5SFRWUWlPd29KSW1sekxXbHVMV2x1ZEhKdkxXOW1abVZ5TFhCbGNtbHZaQ0lnUFNBaVptRnNjMlVpT3dvSkluQjFjbU5vWVhObExXUmhkR1V0YlhNaUlEMGdJakUxT1RNeU1UWXhOVGt3TURBaU93b0pJbVY0Y0dseVpYTXRaR0YwWlMxbWIzSnRZWFIwWldRdGNITjBJaUE5SUNJeU1ESXdMVEEzTFRJMklERTNPakF5T2pNNUlFRnRaWEpwWTJFdlRHOXpYMEZ1WjJWc1pYTWlPd29KSW1sekxYUnlhV0ZzTFhCbGNtbHZaQ0lnUFNBaVptRnNjMlVpT3dvSkltbDBaVzB0YVdRaUlEMGdJamsxT0Rjd05qQXpOU0k3Q2draWRXNXBjWFZsTFdsa1pXNTBhV1pwWlhJaUlEMGdJakF3TURBNE1ESTNMVEF3TVRFME9UVkRNVFF4TXpBd01rVWlPd29KSW05eWFXZHBibUZzTFhSeVlXNXpZV04wYVc5dUxXbGtJaUE5SUNJeU5qQXdNREEzTWpZNE9EZ3hNRGNpT3dvSkltVjRjR2x5WlhNdFpHRjBaU0lnUFNBaU1UVTVOVGd3T0RFMU9UQXdNQ0k3Q2draVlYQndMV2wwWlcwdGFXUWlJRDBnSWpRM09EWXhOekEyTVNJN0Nna2lkSEpoYm5OaFkzUnBiMjR0YVdRaUlEMGdJakkyTURBd01EY3lOamc0T0RFd055STdDZ2tpWW5aeWN5SWdQU0FpTVRBM01ETWlPd29KSW5kbFlpMXZjbVJsY2kxc2FXNWxMV2wwWlcwdGFXUWlJRDBnSWpJMk1EQXdNREkzTmpneU1EQXdNaUk3Q2draWRtVnljMmx2YmkxbGVIUmxjbTVoYkMxcFpHVnVkR2xtYVdWeUlpQTlJQ0k0TXpZek5EVTBNREFpT3dvSkltSnBaQ0lnUFNBaVkyOXRMbVZrZFdOeVpXRjBhVzl1Y3k1cGIzTXVSV1IxWTNKbFlYUnBiMjV6SWpzS0NTSndjbTlrZFdOMExXbGtJaUE5SUNKamIyMHVaV1IxWTNKbFlYUnBiMjV6TG5CeWIzUmxZV05vWlhJdU1XMXZiblJvSWpzS0NTSndkWEpqYUdGelpTMWtZWFJsSWlBOUlDSXlNREl3TFRBMkxUSTNJREF3T2pBeU9qTTVJRVYwWXk5SFRWUWlPd29KSW5CMWNtTm9ZWE5sTFdSaGRHVXRjSE4wSWlBOUlDSXlNREl3TFRBMkxUSTJJREUzT2pBeU9qTTVJRUZ0WlhKcFkyRXZURzl6WDBGdVoyVnNaWE1pT3dvSkltOXlhV2RwYm1Gc0xYQjFjbU5vWVhObExXUmhkR1VpSUQwZ0lqSXdNakF0TURZdE1qY2dNREE2TURJNk5ESWdSWFJqTDBkTlZDSTdDbjA9IjsKCSJwb2QiID0gIjI2IjsKCSJzaWduaW5nLXN0YXR1cyIgPSAiMCI7Cn0=",
+        "latest_receipt_info": {
+            "app_item_id": "478617061",
+            "bid": "com.educreations.ios.Educreations",
+            "bvrs": "10703",
+            "expires_date": "1595808159000",
+            "expires_date_formatted": "2020-07-27 00:02:39 Etc/GMT",
+            "expires_date_formatted_pst": "2020-07-26 17:02:39 America/Los_Angeles",
+            "is_in_intro_offer_period": "false",
+            "is_trial_period": "false",
+            "item_id": "958706035",
+            "original_purchase_date": "2020-06-27 00:02:42 Etc/GMT",
+            "original_purchase_date_ms": "1593216162000",
+            "original_purchase_date_pst": "2020-06-26 17:02:42 America/Los_Angeles",
+            "original_transaction_id": "260000726888107",
+            "product_id": "com.educreations.proteacher.1month",
+            "purchase_date": "2020-06-27 00:02:39 Etc/GMT",
+            "purchase_date_ms": "1593216159000",
+            "purchase_date_pst": "2020-06-26 17:02:39 America/Los_Angeles",
+            "quantity": "1",
+            "subscription_group_identifier": "19974122",
+            "transaction_id": "260000726888107",
+            "unique_identifier": "00008027-0011495C1413002E",
+            "unique_vendor_identifier": "D58CBBCE-A3AA-4E93-AC24-50049702C82F",
+            "version_external_identifier": "836345400",
+            "web_order_line_item_id": "260000276820002",
+        },
+        "notification_type": "INITIAL_BUY",
+        "password": "646ac176112348e8a81ba53b6ca2471c",
+        "unified_receipt": {
+            "environment": "Production",
+            "latest_receipt": "MIIUDwYJKoZIhvcNAQcCoIIUADCCE/wCAQExCzAJBgUrDgMCGgUAMIIDsAYJKoZIhvcNAQcBoIIDoQSCA50xggOZMAoCARMCAQEEAgwAMAoCARQCAQEEAgwAMAsCARkCAQEEAwIBAzAMAgEOAgEBBAQCAgDDMA0CAQsCAQEEBQIDCiZiMA0CAQ0CAQEEBQIDAf3FMA4CAQECAQEEBgIEHIcd5TAOAgEJAgEBBAYCBFAyNTMwDgIBCgIBAQQGFgRub25lMA4CARACAQEEBgIEMdmeODAPAgEDAgEBBAcMBTEwNzAzMBQCAQACAQEEDAwKUHJvZHVjdGlvbjAYAgEEAgECBBDd+TETKHYyspHAG900qpy6MBwCAQUCAQEEFI51s4zGAv0zrOcof3zwu7IfcyZcMB4CAQgCAQEEFhYUMjAyMC0wNi0yN1QwMDowMjozOVowHgIBDAIBAQQWFhQyMDIwLTA2LTI3VDAwOjAzOjAyWjAeAgESAgEBBBYWFDIwMjAtMDYtMjdUMDA6MDI6MzlaMCsCAQICAQEEIwwhY29tLmVkdWNyZWF0aW9ucy5pb3MuRWR1Y3JlYXRpb25zMD4CAQcCAQEENqX4lK25SOGmGE6GgxzGZnjbxkkqVM+Xw1lAwNzh7K6ms4g8nGjZzl0OOTVIorPGEgx9VVHK1jBGAgEGAgEBBD49th2SFq4KVzxazvS7VTExN1XCPz0B2N7rxjc+xtr2cYeuVibJevdYBx3vHkzJonS1GuoQty5R/l8qunTGpzCCAZACARECAQEEggGGMYIBgjALAgIGrQIBAQQCDAAwCwICBrACAQEEAhYAMAsCAgayAgEBBAIMADALAgIGswIBAQQCDAAwCwICBrQCAQEEAgwAMAsCAga1AgEBBAIMADALAgIGtgIBAQQCDAAwDAICBqUCAQEEAwIBATAMAgIGqwIBAQQDAgEDMAwCAgaxAgEBBAMCAQAwDAICBrcCAQEEAwIBADAPAgIGrgIBAQQGAgQ5JLFzMBICAgavAgEBBAkCBwDseAgkMCIwGgICBqcCAQEEEQwPMjYwMDAwNzI2ODg4MTA3MBoCAgapAgEBBBEMDzI2MDAwMDcyNjg4ODEwNzAfAgIGqAIBAQQWFhQyMDIwLTA2LTI3VDAwOjAyOjM5WjAfAgIGqgIBAQQWFhQyMDIwLTA2LTI3VDAwOjAyOjQyWjAfAgIGrAIBAQQWFhQyMDIwLTA3LTI3VDAwOjAyOjM5WjAtAgIGpgIBAQQkDCJjb20uZWR1Y3JlYXRpb25zLnByb3RlYWNoZXIuMW1vbnRooIIOZTCCBXwwggRkoAMCAQICCA7rV4fnngmNMA0GCSqGSIb3DQEBBQUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECgwKQXBwbGUgSW5jLjEsMCoGA1UECwwjQXBwbGUgV29ybGR3aWRlIERldmVsb3BlciBSZWxhdGlvbnMxRDBCBgNVBAMMO0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTE1MTExMzAyMTUwOVoXDTIzMDIwNzIxNDg0N1owgYkxNzA1BgNVBAMMLk1hYyBBcHAgU3RvcmUgYW5kIGlUdW5lcyBTdG9yZSBSZWNlaXB0IFNpZ25pbmcxLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zMRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXPgf0looFb1oftI9ozHI7iI8ClxCbLPcaf7EoNVYb/pALXl8o5VG19f7JUGJ3ELFJxjmR7gs6JuknWCOW0iHHPP1tGLsbEHbgDqViiBD4heNXbt9COEo2DTFsqaDeTwvK9HsTSoQxKWFKrEuPt3R+YFZA1LcLMEsqNSIH3WHhUa+iMMTYfSgYMR1TzN5C4spKJfV+khUrhwJzguqS7gpdj9CuTwf0+b8rB9Typj1IawCUKdg7e/pn+/8Jr9VterHNRSQhWicxDkMyOgQLQoJe2XLGhaWmHkBBoJiY5uB0Qc7AKXcVz0N92O9gt2Yge4+wHz+KO0NP6JlWB7+IDSSMCAwEAAaOCAdcwggHTMD8GCCsGAQUFBwEBBDMwMTAvBggrBgEFBQcwAYYjaHR0cDovL29jc3AuYXBwbGUuY29tL29jc3AwMy13d2RyMDQwHQYDVR0OBBYEFJGknPzEdrefoIr0TfWPNl3tKwSFMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUiCcXCam2GGCL7Ou69kdZxVJUo7cwggEeBgNVHSAEggEVMIIBETCCAQ0GCiqGSIb3Y2QFBgEwgf4wgcMGCCsGAQUFBwICMIG2DIGzUmVsaWFuY2Ugb24gdGhpcyBjZXJ0aWZpY2F0ZSBieSBhbnkgcGFydHkgYXNzdW1lcyBhY2NlcHRhbmNlIG9mIHRoZSB0aGVuIGFwcGxpY2FibGUgc3RhbmRhcmQgdGVybXMgYW5kIGNvbmRpdGlvbnMgb2YgdXNlLCBjZXJ0aWZpY2F0ZSBwb2xpY3kgYW5kIGNlcnRpZmljYXRpb24gcHJhY3RpY2Ugc3RhdGVtZW50cy4wNgYIKwYBBQUHAgEWKmh0dHA6Ly93d3cuYXBwbGUuY29tL2NlcnRpZmljYXRlYXV0aG9yaXR5LzAOBgNVHQ8BAf8EBAMCB4AwEAYKKoZIhvdjZAYLAQQCBQAwDQYJKoZIhvcNAQEFBQADggEBAA2mG9MuPeNbKwduQpZs0+iMQzCCX+Bc0Y2+vQ+9GvwlktuMhcOAWd/j4tcuBRSsDdu2uP78NS58y60Xa45/H+R3ubFnlbQTXqYZhnb4WiCV52OMD3P86O3GH66Z+GVIXKDgKDrAEDctuaAEOR9zucgF/fLefxoqKm4rAfygIFzZ630npjP49ZjgvkTbsUxn/G4KT8niBqjSl/OnjmtRolqEdWXRFgRi48Ff9Qipz2jZkgDJwYyz+I0AZLpYYMB8r491ymm5WyrWHWhumEL1TKc3GZvMOxx6GUPzo22/SGAGDDaSK+zeGLUR2i0j0I78oGmcFxuegHs5R0UwYS/HE6gwggQiMIIDCqADAgECAggB3rzEOW2gEDANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwHhcNMTMwMjA3MjE0ODQ3WhcNMjMwMjA3MjE0ODQ3WjCBljELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zMUQwQgYDVQQDDDtBcHBsZSBXb3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9ucyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMo4VKbLVqrIJDlI6Yzu7F+4fyaRvDRTes58Y4Bhd2RepQcjtjn+UC0VVlhwLX7EbsFKhT4v8N6EGqFXya97GP9q+hUSSRUIGayq2yoy7ZZjaFIVPYyK7L9rGJXgA6wBfZcFZ84OhZU3au0Jtq5nzVFkn8Zc0bxXbmc1gHY2pIeBbjiP2CsVTnsl2Fq/ToPBjdKT1RpxtWCcnTNOVfkSWAyGuBYNweV3RY1QSLorLeSUheHoxJ3GaKWwo/xnfnC6AllLd0KRObn1zeFM78A7SIym5SFd/Wpqu6cWNWDS5q3zRinJ6MOL6XnAamFnFbLw/eVovGJfbs+Z3e8bY/6SZasCAwEAAaOBpjCBozAdBgNVHQ4EFgQUiCcXCam2GGCL7Ou69kdZxVJUo7cwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBQr0GlHlHYJ/vRrjS5ApvdHTX8IXjAuBgNVHR8EJzAlMCOgIaAfhh1odHRwOi8vY3JsLmFwcGxlLmNvbS9yb290LmNybDAOBgNVHQ8BAf8EBAMCAYYwEAYKKoZIhvdjZAYCAQQCBQAwDQYJKoZIhvcNAQEFBQADggEBAE/P71m+LPWybC+P7hOHMugFNahui33JaQy52Re8dyzUZ+L9mm06WVzfgwG9sq4qYXKxr83DRTCPo4MNzh1HtPGTiqN0m6TDmHKHOz6vRQuSVLkyu5AYU2sKThC22R1QbCGAColOV4xrWzw9pv3e9w0jHQtKJoc/upGSTKQZEhltV/V6WId7aIrkhoxK6+JJFKql3VUAqa67SzCu4aCxvCmA5gl35b40ogHKf9ziCuY7uLvsumKV8wVjQYLNDzsdTJWk26v5yZXpT+RN5yaZgem8+bQp0gF6ZuEujPYhisX4eOGBrr/TkJ2prfOv/TgalmcwHFGlXOxxioK0bA8MFR8wggS7MIIDo6ADAgECAgECMA0GCSqGSIb3DQEBBQUAMGIxCzAJBgNVBAYTAlVTMRMwEQYDVQQKEwpBcHBsZSBJbmMuMSYwJAYDVQQLEx1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTEWMBQGA1UEAxMNQXBwbGUgUm9vdCBDQTAeFw0wNjA0MjUyMTQwMzZaFw0zNTAyMDkyMTQwMzZaMGIxCzAJBgNVBAYTAlVTMRMwEQYDVQQKEwpBcHBsZSBJbmMuMSYwJAYDVQQLEx1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTEWMBQGA1UEAxMNQXBwbGUgUm9vdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOSRqQkfkdseR1DrBe1eeYQt6zaiV0xV7IsZid75S2z1B6siMALoGD74UAnTf0GomPnRymacJGsR0KO75Bsqwx+VnnoMpEeLW9QWNzPLxA9NzhRp0ckZcvVdDtV/X5vyJQO6VY9NXQ3xZDUjFUsVWR2zlPf2nJ7PULrBWFBnjwi0IPfLrCwgb3C2PwEwjLdDzw+dPfMrSSgayP7OtbkO2V4c1ss9tTqt9A8OAJILsSEWLnTVPA3bYharo3GSR1NVwa8vQbP4++NwzeajTEV+H0xrUJZBicR0YgsQg0GHM4qBsTBY7FoEMoxos48d3mVz/2deZbxJ2HafMxRloXeUyS0CAwEAAaOCAXowggF2MA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQr0GlHlHYJ/vRrjS5ApvdHTX8IXjAfBgNVHSMEGDAWgBQr0GlHlHYJ/vRrjS5ApvdHTX8IXjCCAREGA1UdIASCAQgwggEEMIIBAAYJKoZIhvdjZAUBMIHyMCoGCCsGAQUFBwIBFh5odHRwczovL3d3dy5hcHBsZS5jb20vYXBwbGVjYS8wgcMGCCsGAQUFBwICMIG2GoGzUmVsaWFuY2Ugb24gdGhpcyBjZXJ0aWZpY2F0ZSBieSBhbnkgcGFydHkgYXNzdW1lcyBhY2NlcHRhbmNlIG9mIHRoZSB0aGVuIGFwcGxpY2FibGUgc3RhbmRhcmQgdGVybXMgYW5kIGNvbmRpdGlvbnMgb2YgdXNlLCBjZXJ0aWZpY2F0ZSBwb2xpY3kgYW5kIGNlcnRpZmljYXRpb24gcHJhY3RpY2Ugc3RhdGVtZW50cy4wDQYJKoZIhvcNAQEFBQADggEBAFw2mUwteLftjJvc83eb8nbSdzBPwR+Fg4UbmT1HN/Kpm0COLNSxkBLYvvRzm+7SZA/LeU802KI++Xj/a8gH7H05g4tTINM4xLG/mk8Ka/8r/FmnBQl8F0BWER5007eLIztHo9VvJOLr0bdw3w9F4SfK8W147ee1Fxeo3H4iNcol1dkP1mvUoiQjEfehrI9zgWDGG1sJL5Ky+ERI8GA4nhX1PSZnIIozavcNgs/e66Mv+VNqW2TAYzN39zoHLFbr2g8hDtq6cxlPtdk2f8GHVdmnmbkyQvvY1XGefqFStxu9k0IkEirHDx22TZxeY8hLgBdQqorV2uT80AkHN7B1dSExggHLMIIBxwIBATCBozCBljELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZlbG9wZXIgUmVsYXRpb25zMUQwQgYDVQQDDDtBcHBsZSBXb3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9ucyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eQIIDutXh+eeCY0wCQYFKw4DAhoFADANBgkqhkiG9w0BAQEFAASCAQCdB1UwJ9Fe91rxbACjhUY80XOG4J+dmgoIbE+k0zjwu/UimWPyRTd46rpI69IQHYOqpkDsy6JGOjp3lywHV2FXCIxVxp1D3+nTDUcEb3ApNWPrV8IpHzy+kcj79qcBeDYdPe5vE2aDXFMn76Nx5SJ29wzu9IYxSnQbw/zhoReFV6mVVGiEn3FSS4WRs5PXshkZb3PHYHQRpJCMZyyzrcq63DRxqQRYwyfGG8wa/cq9KkNEUR5oJZsw+r9b+CH6cLtED0ZjRe1ZxaUbd12IgNtkLgmRTCQNPyGFrd5PEjDhiE9AzdyPRkpYg020nYmfUZ4ABuuztMlozRD31jjSVLOA",
+            "latest_receipt_info": [
+                {
+                    "expires_date": "2020-07-27 00:02:39 Etc/GMT",
+                    "expires_date_ms": "1595808159000",
+                    "expires_date_pst": "2020-07-26 17:02:39 America/Los_Angeles",
+                    "is_in_intro_offer_period": "false",
+                    "is_trial_period": "false",
+                    "original_purchase_date": "2020-06-27 00:02:42 Etc/GMT",
+                    "original_purchase_date_ms": "1593216162000",
+                    "original_purchase_date_pst": "2020-06-26 17:02:42 America/Los_Angeles",
+                    "original_transaction_id": "260000726888107",
+                    "product_id": "com.educreations.proteacher.1month",
+                    "purchase_date": "2020-06-27 00:02:39 Etc/GMT",
+                    "purchase_date_ms": "1593216159000",
+                    "purchase_date_pst": "2020-06-26 17:02:39 America/Los_Angeles",
+                    "quantity": "1",
+                    "subscription_group_identifier": "19974122",
+                    "transaction_id": "260000726888107",
+                    "web_order_line_item_id": "260000276820002",
+                }
+            ],
+            "pending_renewal_info": [
+                {
+                    "auto_renew_product_id": "com.educreations.proteacher.1month",
+                    "auto_renew_status": "1",
+                    "original_transaction_id": "260000726888107",
+                    "product_id": "com.educreations.proteacher.1month",
+                }
+            ],
+            "status": 0,
+        },
+    }
+
+    form = AppleStatusUpdateForm(data)
+    assert form.is_valid(), form.errors.as_data()


### PR DESCRIPTION
Updated parsing, including more recent libraries, and less low level openssl modules. Some tips from https://www.revenuecat.com/blog/dissecting-an-app-store-receipt

Also, add more forms for parsing receipts.

Finally, this is a breaking change with a new setting.